### PR TITLE
don't add/del the wakeup fd to the event_loop registered fd list

### DIFF
--- a/examples/usr/hello_world/xio_client.c
+++ b/examples/usr/hello_world/xio_client.c
@@ -89,7 +89,7 @@ static int on_session_event(struct xio_session *session,
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
 		xio_session_close(session);
-		xio_ev_loop_stop(session_data->loop);  /* exit */
+		xio_ev_loop_stop(session_data->loop, 0);  /* exit */
 		break;
 	default:
 		break;

--- a/examples/usr/hello_world_mt/xio_mt_client.c
+++ b/examples/usr/hello_world_mt/xio_mt_client.c
@@ -154,7 +154,7 @@ static int on_session_event(struct xio_session *session,
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
 		for (i = 0; i < MAX_THREADS; i++)
-			xio_ev_loop_stop(session_data->tdata[i].loop);
+			xio_ev_loop_stop(session_data->tdata[i].loop, 0);
 		break;
 	default:
 		break;

--- a/include/xio_user.h
+++ b/include/xio_user.h
@@ -1082,8 +1082,9 @@ int xio_ev_loop_run_timeout(void *loop_hndl, int timeout_msec);
  * stop a running event loop main loop
  *
  * @param[in] loop		Pointer to event loop
+ * @param[in] is_self_thread	lighter stop if called from within ev_loop callbacks
  */
-void xio_ev_loop_stop(void *loop);
+void xio_ev_loop_stop(void *loop, int is_self_thread);
 
 /**
  * destroy the event loop

--- a/src/usr/xio_ev_loop.c
+++ b/src/usr/xio_ev_loop.c
@@ -328,7 +328,7 @@ int xio_ev_loop_run(void *loop_hndl)
 /*---------------------------------------------------------------------------*/
 /* xio_ev_loop_stop                                                        */
 /*---------------------------------------------------------------------------*/
-inline void xio_ev_loop_stop(void *loop_hndl)
+inline void xio_ev_loop_stop(void *loop_hndl, int is_self_thread)
 {
 	struct xio_ev_loop	*loop = loop_hndl;
 
@@ -339,7 +339,7 @@ inline void xio_ev_loop_stop(void *loop_hndl)
 		return; /* loop is already marked for stopping (and also armed for wakeup from blocking) */
 	loop->stop_loop = 1;
 
-	if (loop->wakeup_armed == 1)
+	if (is_self_thread || loop->wakeup_armed == 1)
 		return; /* wakeup is still armed, probably left loop in previous cycle due to other reasons (timeout, events) */
 	loop->wakeup_armed = 1;
 	xio_ev_loop_modify(loop, loop->wakeup_event, XIO_POLLIN | XIO_POLLLT | XIO_ONESHOT);

--- a/src/usr/xio_rdma_management.c
+++ b/src/usr/xio_rdma_management.c
@@ -185,7 +185,7 @@ static int xio_device_thread_init()
 /*---------------------------------------------------------------------------*/
 static void xio_device_thread_stop()
 {
-	xio_ev_loop_stop(dev_tdata.async_loop);
+	xio_ev_loop_stop(dev_tdata.async_loop, 0);
 
 	pthread_join(dev_tdata.dev_thread, NULL);
 }

--- a/tests/usr/hello_test/xio_client.c
+++ b/tests/usr/hello_test/xio_client.c
@@ -228,7 +228,7 @@ static int on_session_event(struct xio_session *session,
 		       last_sent,  last_recv, last_sent-last_recv);
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
-		xio_ev_loop_stop(loop);  /* exit */
+		xio_ev_loop_stop(loop, 0);  /* exit */
 		if (pool) {
 			msg_pool_free(pool);
 			pool = NULL;

--- a/tests/usr/hello_test_bidi/xio_bidi_client.c
+++ b/tests/usr/hello_test_bidi/xio_bidi_client.c
@@ -241,7 +241,7 @@ static int on_session_event(struct xio_session *session,
 		xio_disconnect(event_data->conn);
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
-		xio_ev_loop_stop(loop);  /* exit */
+		xio_ev_loop_stop(loop, 0);  /* exit */
 		break;
 	default:
 		break;

--- a/tests/usr/hello_test_lat/xio_lat_client.c
+++ b/tests/usr/hello_test_lat/xio_lat_client.c
@@ -218,7 +218,7 @@ static int on_session_event(struct xio_session *session,
 		xio_disconnect(event_data->conn);
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
-		xio_ev_loop_stop(loop);  /* exit */
+		xio_ev_loop_stop(loop, 0);  /* exit */
 		break;
 	default:
 		break;

--- a/tests/usr/hello_test_mt/xio_mt_client.c
+++ b/tests/usr/hello_test_mt/xio_mt_client.c
@@ -332,7 +332,7 @@ static int on_session_event(struct xio_session *session,
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
 		for (i = 0; i < MAX_THREADS; i++)
-			xio_ev_loop_stop(session_data->tdata[i].loop);
+			xio_ev_loop_stop(session_data->tdata[i].loop, 0);
 		break;
 	default:
 		break;

--- a/tests/usr/hello_test_mt/xio_mt_server.c
+++ b/tests/usr/hello_test_mt/xio_mt_server.c
@@ -406,9 +406,9 @@ static int on_session_event(struct xio_session *session,
 		xio_session_close(session);
 		for (i = 0; i < server_data->tdata_nr; i++) {
 			process_request(&server_data->tdata[i], NULL);
-			xio_ev_loop_stop(server_data->tdata[i].loop);
+			xio_ev_loop_stop(server_data->tdata[i].loop, 0);
 		}
-		xio_ev_loop_stop(server_data->loop);
+		xio_ev_loop_stop(server_data->loop, 0);
 		break;
 	default:
 		break;

--- a/tests/usr/hello_test_oneway/xio_oneway_client.c
+++ b/tests/usr/hello_test_oneway/xio_oneway_client.c
@@ -263,7 +263,7 @@ static int on_session_event(struct xio_session *session,
 		xio_disconnect(event_data->conn);
 		break;
 	case XIO_SESSION_TEARDOWN_EVENT:
-		xio_ev_loop_stop(loop);  /* exit */
+		xio_ev_loop_stop(loop, 0);  /* exit */
 		break;
 	default:
 		break;

--- a/tests/usr/hello_test_oneway/xio_oneway_server.c
+++ b/tests/usr/hello_test_oneway/xio_oneway_server.c
@@ -178,7 +178,7 @@ static int on_session_event(struct xio_session *session,
 		process_request(NULL);
 		xio_session_close(session);
 		connection = NULL;
-		xio_ev_loop_stop(loop);
+		xio_ev_loop_stop(loop, 0);
 		break;
 	default:
 		break;


### PR DESCRIPTION
this fixes the unsafe list which causes a core in list_del() if
xio_ev_loop_stop() is called different thread then the one running that
event_loop
