### PR TITLE
deprecate _BSD_SOURCE in flavor of _DEFAULT_SOURCE

### DIFF
--- a/benchmarks/usr/xio_perftest/get_clock.c
+++ b/benchmarks/usr/xio_perftest/get_clock.c
@@ -38,6 +38,7 @@
 
 /* For gettimeofday */
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <sys/time.h>
 
 #include <unistd.h>

--- a/examples/usr/raio/get_clock.c
+++ b/examples/usr/raio/get_clock.c
@@ -38,6 +38,7 @@
 
 /* For gettimeofday */
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <sys/time.h>
 
 #include <unistd.h>

--- a/src/usr/xio/get_clock.c
+++ b/src/usr/xio/get_clock.c
@@ -38,6 +38,7 @@
 
 /* For gettimeofday */
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <xio_env.h>
 
 #include <stdio.h>


### PR DESCRIPTION
gcc complains at seeing `_BSD_SOURCE` if `_DEFAULT_SOURCE` is not defined. and it is promoted to an error because we have "-Werror" in `CFLAGS`.

if we do not want to support glibc 2.19 or lower, we can simply define `_DEFAULT_SOURCE`
see http://man7.org/linux/man-pages/man7/feature_test_macros.7.html