### PR TITLE
update xio_set_opt for bug of queue depth bytes.

### DIFF
--- a/src/common/xio_options.c
+++ b/src/common/xio_options.c
@@ -205,12 +205,12 @@ static int xio_general_set_opt(void *xio_obj, int optname,
 		g_options.rcv_queue_depth_msgs = *((int *)optval);
 		return 0;
 	case XIO_OPTNAME_SND_QUEUE_DEPTH_BYTES:
-		if (*((int32_t *)optval) < 1)
+		if (*((uint64_t *)optval) < 1)
 			break;
 		g_options.snd_queue_depth_bytes = *((uint64_t *)optval);
 		return 0;
 	case XIO_OPTNAME_RCV_QUEUE_DEPTH_BYTES:
-		if (*((int32_t *)optval) < 1)
+		if (*((uint64_t *)optval) < 1)
 			break;
 		g_options.rcv_queue_depth_bytes = *((uint64_t *)optval);
 		return 0;

--- a/src/usr/transport/xio_mempool.c
+++ b/src/usr/transport/xio_mempool.c
@@ -325,7 +325,7 @@ static struct xio_mem_block *xio_mem_slab_resize(struct xio_mem_slab *slab,
 	size_t				region_alloc_sz;
 	size_t				data_alloc_sz;
 	int				i;
-	int				aligned_sz;
+	size_t			aligned_sz;
 
 	if (slab->curr_mb_nr == 0) {
 		if (slab->init_mb_nr > slab->max_mb_nr)


### PR DESCRIPTION
Change type from int to uint64_t when set XIO_OPTNAME_SND_QUEUE_DEPTH_BYTES and XIO_OPTNAME_RCV_QUEUE_DEPTH_BYTES