### PR TITLE
Fix bug the type mismatch.

### DIFF
--- a/src/usr/transport/xio_mempool.c
+++ b/src/usr/transport/xio_mempool.c
@@ -325,7 +325,7 @@ static struct xio_mem_block *xio_mem_slab_resize(struct xio_mem_slab *slab,
 	size_t				region_alloc_sz;
 	size_t				data_alloc_sz;
 	int				i;
-	int				aligned_sz;
+	size_t			aligned_sz;
 
 	if (slab->curr_mb_nr == 0) {
 		if (slab->init_mb_nr > slab->max_mb_nr)


### PR DESCRIPTION
It will cause overflow in line xio_mempool.c:357 before.