### PR TITLE
accelio: use macro instead of numeric literal

### DIFF
--- a/src/usr/xio/xio_context.c
+++ b/src/usr/xio/xio_context.c
@@ -475,7 +475,7 @@ int xio_context_run_loop(struct xio_context *ctx, int timeout_ms)
 	int retval = 0;
 
 	ctx->is_running = 1;
-	retval = (timeout_ms == -1) ? xio_ev_loop_run(ctx->ev_loop) :
+	retval = (timeout_ms == XIO_INFINITE) ? xio_ev_loop_run(ctx->ev_loop) :
 		  xio_ev_loop_run_timeout(ctx->ev_loop, timeout_ms);
 	ctx->is_running = 0;
 


### PR DESCRIPTION
This commit lets xio_context_run_loop() use a macro (XIO_INFINITE)
instead of numeric literal (-1) for reader friendliness.

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>