### PR TITLE
accelio/raio: Fix build break for newer fio release. iodepth_batch_complete -> iodepth_batch_complete_min

### DIFF
--- a/examples/raio/usr/fio/libraio.c
+++ b/examples/raio/usr/fio/libraio.c
@@ -130,7 +130,7 @@ static int fio_libraio_getevents(struct thread_data *td, unsigned int min,
 				 unsigned int max, const struct timespec *t)
 {
 	struct libraio_data *ld = td->io_ops->data;
-	unsigned actual_min = td->o.iodepth_batch_complete == 0 ? 0 : min;
+	unsigned actual_min = td->o.iodepth_batch_complete_min == 0 ? 0 : min;
 	int r, events = 0;
 
 	do {


### PR DESCRIPTION
commit 82407585a3b3b10281428e4ca9c2d3e7dfca7392 in fio introduced iodepth_batch_complete_max changing iodepth_batch_complete to iodepth_batch_complete_min. This causes build break when using newer fio branch.
