### PR TITLE
accelio/client: nexus shared by multiple connections should trigger "…

### DIFF
--- a/src/common/xio_nexus.c
+++ b/src/common/xio_nexus.c
@@ -2030,9 +2030,10 @@ int xio_nexus_connect(struct xio_nexus *nexus, const char *portal_uri,
 		nexus->observer_event.observable = &nexus->observable;
 		nexus->observer_event.event = XIO_NEXUS_EVENT_ESTABLISHED;
 		nexus->observer_event.event_data = NULL;
-		xio_ctx_add_work(nexus->transport_hndl->ctx, &nexus->observer_event,
-				xio_observable_notify_observer_wrapper, &nexus->observer_work);
-
+		xio_ctx_add_work(nexus->transport_hndl->ctx,
+                                 &nexus->observer_event,
+                                 xio_observable_notify_all_observers_wrapper,
+                                 &nexus->observer_work);
 		break;
 	default:
 		break;

--- a/src/common/xio_observer.c
+++ b/src/common/xio_observer.c
@@ -193,13 +193,28 @@ EXPORT_SYMBOL(xio_observable_unreg_observer);
 
 
 /*---------------------------------------------------------------------------*/
-/* xio_observable_notify_observer_wrapper					     */
+/* xio_observable_notify_observer_wrapper                                    */
 /*---------------------------------------------------------------------------*/
 void xio_observable_notify_observer_wrapper(void *_observer_event)
 {
-	struct xio_observer_event *observer_event = (struct xio_observer_event *) _observer_event;
-	xio_observable_notify_observer(observer_event->observable, observer_event->observer,
-			observer_event->event, observer_event->event_data);
+	struct xio_observer_event *observer_event =
+                (struct xio_observer_event *) _observer_event;
+	xio_observable_notify_observer(observer_event->observable,
+                                       observer_event->observer,
+                                       observer_event->event,
+                                       observer_event->event_data);
+}
+
+/*---------------------------------------------------------------------------*/
+/* xio_observable_notify_observer_wrapper                                    */
+/*---------------------------------------------------------------------------*/
+void xio_observable_notify_all_observers_wrapper(void *_observer_event)
+{
+	struct xio_observer_event *observer_event =
+                (struct xio_observer_event *) _observer_event;
+	xio_observable_notify_all_observers(observer_event->observable,
+                                            observer_event->event,
+                                            observer_event->event_data);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/common/xio_observer.h
+++ b/src/common/xio_observer.h
@@ -137,8 +137,13 @@ static inline int xio_observable_is_empty(struct xio_observable *observable)
 }
 
 /*---------------------------------------------------------------------------*/
-/* xio_observable_notify_observer_wrapper					     */
+/* xio_observable_notify_observer_wrapper				     */
 /*---------------------------------------------------------------------------*/
 void xio_observable_notify_observer_wrapper(void *_observer_event);
+
+/*---------------------------------------------------------------------------*/
+/* xio_observable_notify_all_observers_wrapper				     */
+/*---------------------------------------------------------------------------*/
+void xio_observable_notify_all_observers_wrapper(void *_observer_event);
 
 #endif /* XIO_OBSERVER_H */


### PR DESCRIPTION
…established" notification to each of its connections (observers)

Signed-off-by: Eyal Salomon <eyals@iguaz.io>