### PR TITLE
accelio/nexus: multiple "connection established" notifications were not posted

### DIFF
--- a/src/common/xio_nexus.h
+++ b/src/common/xio_nexus.h
@@ -169,10 +169,7 @@ struct xio_nexus {
 	struct xio_ev_data		destroy_event;
 	struct xio_ev_data		trans_error_event;
 	spinlock_t			nexus_obs_lock;
-	int 					pad2;
-
-	struct xio_observer_event	observer_event;
-	xio_work_handle_t               observer_work;
+	int 				pad2;
 	struct mutex			lock_connect;      /* lock nexus connect */
 
 	HT_ENTRY(xio_nexus, xio_key_int32) nexus_htbl;

--- a/src/common/xio_observer.c
+++ b/src/common/xio_observer.c
@@ -191,17 +191,6 @@ void xio_observable_unreg_observer(struct xio_observable *observable,
 }
 EXPORT_SYMBOL(xio_observable_unreg_observer);
 
-
-/*---------------------------------------------------------------------------*/
-/* xio_observable_notify_observer_wrapper					     */
-/*---------------------------------------------------------------------------*/
-void xio_observable_notify_observer_wrapper(void *_observer_event)
-{
-	struct xio_observer_event *observer_event = (struct xio_observer_event *) _observer_event;
-	xio_observable_notify_observer(observer_event->observable, observer_event->observer,
-			observer_event->event, observer_event->event_data);
-}
-
 /*---------------------------------------------------------------------------*/
 /* xio_observable_notify_observer					     */
 /*---------------------------------------------------------------------------*/

--- a/src/common/xio_observer.h
+++ b/src/common/xio_observer.h
@@ -136,9 +136,4 @@ static inline int xio_observable_is_empty(struct xio_observable *observable)
 	return list_empty(&observable->observers_list);
 }
 
-/*---------------------------------------------------------------------------*/
-/* xio_observable_notify_observer_wrapper					     */
-/*---------------------------------------------------------------------------*/
-void xio_observable_notify_observer_wrapper(void *_observer_event);
-
 #endif /* XIO_OBSERVER_H */


### PR DESCRIPTION
since "work" member was overwritten again and again

Signed-off-by: Eyal Salomon <eyals@iguaz.io>