### PR TITLE
moving work_dtor of nexus_notify_observer_work to

### DIFF
--- a/src/common/xio_nexus.c
+++ b/src/common/xio_nexus.c
@@ -76,6 +76,7 @@ struct xio_event_params {
 struct xio_nexus_observer_work {
 	struct xio_observer_event	observer_event;
 	xio_work_handle_t               observer_work;
+	struct xio_context 	*ctx;
 };
 
 static int xio_msecs[] = {60000, 30000, 15000, 0};
@@ -1997,6 +1998,10 @@ static void xio_nexus_notify_observer_work(void *_work_params)
                                        work_params->observer_event.observer,
                                        work_params->observer_event.event,
                                        work_params->observer_event.event_data);
+	xio_ctx_set_work_destructor(work_params->ctx,
+	                                            work_params,
+	                                            (void (*)(void *))kfree,
+	                                            &work_params->observer_work);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -2054,15 +2059,11 @@ int xio_nexus_connect(struct xio_nexus *nexus, const char *portal_uri,
 		work_params->observer_event.observable = &nexus->observable;
 		work_params->observer_event.event = XIO_NEXUS_EVENT_ESTABLISHED;
 		work_params->observer_event.event_data = NULL;
+		work_params->ctx = nexus->transport_hndl->ctx;
 		xio_ctx_add_work(nexus->transport_hndl->ctx,
                                  work_params,
                                  xio_nexus_notify_observer_work,
                                  &work_params->observer_work);
-                xio_ctx_set_work_destructor(nexus->transport_hndl->ctx,
-                                            work_params,
-                                            (void (*)(void *))kfree,
-                                            &work_params->observer_work);
-
 		break;
 	default:
 		break;


### PR DESCRIPTION
xio_nexus_notify_observer_work to avoid race
Signed-off-by: Katya Katsenelenbogen katyak@mellanox.com
