### PR TITLE
rdma: fix rsp size when calculating rdma write

### DIFF
--- a/src/kernel/transport/rdma/xio_rdma_datapath.c
+++ b/src/kernel/transport/rdma/xio_rdma_datapath.c
@@ -1715,6 +1715,7 @@ static int xio_prep_rdma_op(struct xio_task *task,
 			rdmad->nents			= k + 1;
 			k				= 0;
 
+			rint_len			= 0;
 			tot_len				+= rlen;
 			int_len				+= rlen;
 			tmp_rdma_task->out_ib_op		= xio_out_ib_op;

--- a/src/usr/transport/rdma/xio_rdma_datapath.c
+++ b/src/usr/transport/rdma/xio_rdma_datapath.c
@@ -3280,6 +3280,7 @@ static int xio_prep_rdma_op(
 
 			tot_len				+= rlen;
 			int_len				+= rlen;
+			rint_len			= 0;
 			tmp_rdma_task->out_ib_op	= xio_out_ib_op;
 			tmp_rdma_task->phantom_idx	= task_idx;
 


### PR DESCRIPTION
when have req IN iovec larger then OUT rsp in some cases
bad logic caused bad length to be set in the last sge.
This casues an dest exhausted error in the reciever's side.

Change-Id: If57cf7d58d115325ac2c510043bd7ca66ad3f38f
Signed-off-by: Rafi Wiener rafiw@mellanox.com
