### PR TITLE
fix bad logic in tcp single socket disconnection

### DIFF
--- a/src/usr/transport/tcp/xio_tcp_management.c
+++ b/src/usr/transport/tcp/xio_tcp_management.c
@@ -182,9 +182,8 @@ int xio_tcp_single_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
 {
 	int retval;
 
-        if (tcp_hndl->in_epoll[0])
-                return 0;
-
+	if (!tcp_hndl->in_epoll[0])
+		return 0;
 	/* remove from epoll */
 	retval = xio_context_del_ev_handler(tcp_hndl->base.ctx,
 					    tcp_hndl->sock.cfd);


### PR DESCRIPTION
During the disconnnetion of the single socket tcp mode
bad logic was used. This can easily be seen comparing to
the dual socket function xio_tcp_dual_sock_del_ev_handlers.

Change-Id: I6c21311024a4b6ac461d53fb28d946b269a1f969
Signed-off-by: Rafi Wiener rafiw@mellanox.com
