### PR TITLE
Enable passing arguments to debian pkg build.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ endif
 override_dh_auto_build:
 	dh_testdir
 	./autogen.sh
-	dh_auto_configure
+	dh_auto_configure -- $(ACCELIO_EXTRA_CMAKE_ARGS)
 	dh_auto_build --parallel
 
 override_dh_auto_install:


### PR DESCRIPTION
To create a custom flavored deb package, non-default
configuration options can be passed to the ./configure script via
the ACCELIO_EXTRA_CMAKE_ARGS environment argument.

Example:

  ACCELIO_EXTRA_CMAKE_ARGS="--enable-shared-receive-queue=yes" ./make-deb.sh

Change-Id: I16bf68e670e2bf855f74d6050797cd6d48527278
Signed-off-by: Ilan Smith ilansm@mellanox.com
