### PR TITLE
accelio: task cleanup fields

### DIFF
--- a/src/common/xio_task.h
+++ b/src/common/xio_task.h
@@ -170,18 +170,19 @@ static inline void xio_task_reset(struct xio_task *task)
 {
 	/* user responsibility to reset after receive */
 	/*
-	if (task->imsg.user_context)
-		task->imsg.user_context	= 0;
-
 	task->imsg.flags		= 0;
 	task->tlv_type			= 0xdead;
 	task->omsg_flags		= 0;
 	task->state			= XIO_TASK_STATE_INIT;
 	xio_mbuf_reset(&task->mbuf);
 	*/
-
 	task->sender_task		= NULL;
 	task->tlv_type			= 0xdead;
+	task->status			= 0;
+
+	if (task->imsg.user_context)
+		task->imsg.user_context	= NULL;
+
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
cleanup is required for those specific fields in task structure

Signed-off-by: Eyal Salomon <eyals@iguaz.io>