### PR TITLE
accelio/connection: fix lead connection double closed

### DIFF
--- a/src/common/xio_connection.c
+++ b/src/common/xio_connection.c
@@ -2320,7 +2320,7 @@ static void xio_connection_post_destroy(struct kref *kref)
 	/* leading connection */
 	spin_lock(&session->connections_list_lock);
 	if (session->lead_connection &&
-	    session->lead_connection->nexus == connection->nexus) {
+	    session->lead_connection == connection) {
                 if ((connection->state == XIO_CONNECTION_STATE_INIT ||
                      connection->state == XIO_CONNECTION_STATE_DISCONNECTED ||
                      connection->state == XIO_CONNECTION_STATE_ERROR) &&


### PR DESCRIPTION
session->lead_connection->nexus may become NULL by
xio_nexus_close->xio_on_nexus_closed.

In case the non lead connection hold spinlock first,
the lead connection then double closed by NULL==NULL logic,
and non lead connection never closed.